### PR TITLE
fix social image missing

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -246,7 +246,7 @@ const config: Config = {
       playgroundPosition: 'bottom',
     },
     // Replace with your project's social card
-    image: 'img/docusaurus-social-card.jpg',
+    image: 'img/favicon.svg',
     navbar: {
       // title: 'My Site',
       logo: {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -246,7 +246,7 @@ const config: Config = {
       playgroundPosition: 'bottom',
     },
     // Replace with your project's social card
-    image: 'img/favicon.svg',
+    image: 'assets/icon.png',
     navbar: {
       // title: 'My Site',
       logo: {


### PR DESCRIPTION
As we can see from the meta tag of site
<img width="850" height="29" alt="image" src="https://github.com/user-attachments/assets/0d20e86a-df98-47c2-b08f-18b1dfd2bcff" />
Current social card image points to a non-existing image.
This PR is to change the social card image to webspatial logo.