### PR TITLE
Document the Attachment API in the Reality page

### DIFF
--- a/docs/api/react-sdk/react-components/Reality.md
+++ b/docs/api/react-sdk/react-components/Reality.md
@@ -238,7 +238,14 @@ useEffect(() => {
 
 ## Attachment Entity
 
-`<AttachmentEntity>` is an Entity similar to `<Plane>`. It can reference [predeclared 2D HTML/CSS content](#3d-assets) and attach that content onto its own surface.
+The Attachment API lets you render interactive 2D HTML/React content — buttons, labels, HUDs, info panels — as floating panels attached to 3D entities inside `<Reality>`. The attached content shares the same React component tree and state as the host page: clicking a button inside an attachment can update the host page's state, and host page state changes are reflected inside the attachment in real time.
+
+This API consists of two components with separated responsibilities:
+
+- `<AttachmentAsset>` declares **what** to render (the 2D content template). It is a [3D asset declaration](#3d-assets) placed among the top-level children of `<Reality>`, outside `<World>`.
+- `<AttachmentEntity>` declares **where** to render it (position, size, and parent Entity). It is used inside `<World>`.
+
+This asset-vs-entity separation follows the same pattern as [`<ModelAsset>` / `<ModelEntity>`](#model-entity), and supports one-to-many rendering in the same way: a single content template can be rendered at multiple 3D positions at the same time.
 
 :::caution[Current limitation]
 In a later version of WebSpatial SDK, `<AttachmentEntity>` will support `width` and `height` like `<Plane>` does, which it does not currently support, and full [Transform props](#3d-entity), whereas the current version only supports `position`. For now, you need to use the `size` prop to set the size, with the same `px` unit used by 2D content.
@@ -263,3 +270,107 @@ In a later version of WebSpatial SDK, `<AttachmentEntity>` will support `width` 
   </World>
 </Reality>
 ```
+
+### `<AttachmentAsset>` Props
+
+`name`
+
+Required. A string identifier that links this content template to one or more `<AttachmentEntity>` instances. It must match the `attachment` prop on the corresponding entities.
+
+`children`
+
+The React content to render inside the attachment. This can be any valid React JSX — divs, buttons, styled components, stateful components, and so on. The content shares the host page's React tree, so props, context, and state flow naturally.
+
+Usage rules:
+
+- `<AttachmentAsset>` must be a direct child of `<Reality>`, outside `<World>`.
+- If no `<AttachmentEntity>` references the given `name`, the content is not rendered.
+- When multiple `<AttachmentEntity>` instances reference the same `name`, a copy of the same content template is rendered at each position.
+
+### `<AttachmentEntity>` Props
+
+`attachment`
+
+Required. A string matching the `name` prop on the corresponding `<AttachmentAsset>`.
+
+`position`
+
+Optional. The attachment's local position relative to its parent Entity, using the same `m` unit as other [Transform props](#3d-entity). Defaults to the origin.
+
+`size`
+
+Required. An object `{ width: number, height: number }` that sets the attachment's frame dimensions, with the same `px` unit used by 2D content.
+
+`<AttachmentEntity>` must be used inside `<World>` as a descendant of an Entity. It inherits the parent Entity's transform: when the parent Entity moves, the attachment follows it.
+
+`attachment`, `position`, and `size` can all be changed at runtime. The attachment switches to the new content template or updates its position and size accordingly. When the component unmounts, the corresponding native attachment is destroyed automatically.
+
+### Shared State and One-to-Many Rendering
+
+One content template can be rendered at multiple 3D positions at the same time, and the attached content stays connected to the host page's state:
+
+```js
+import { useState } from "react";
+import {
+  Reality,
+  AttachmentAsset,
+  World,
+  Entity,
+  Sphere,
+  AttachmentEntity,
+} from "@webspatial/react-sdk";
+
+function LabeledSpheres() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Reality style={{ width: "500px", height: "500px", "--xr-depth": 100 }}>
+      {/* One content template, shared with the host page's state */}
+      <AttachmentAsset name="counter">
+        <button onClick={() => setCount(count + 1)}>Clicked {count}</button>
+      </AttachmentAsset>
+      <World>
+        {/* The same template is rendered at two 3D positions */}
+        <Entity position={{ x: -0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+        <Entity position={{ x: 0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+      </World>
+    </Reality>
+  );
+}
+```
+
+:::info[Styles are inherited automatically]
+The 2D content inside an attachment automatically inherits styles from the host page:
+
+- Global styles on the host page, such as `<link rel="stylesheet">` and `<style>`, are synced into the attachment automatically.
+- Class names on the root element are synced as well, so utility-class approaches such as Tailwind work directly.
+- During development, new styles injected by hot module replacement (HMR) are picked up automatically.
+- Relative URLs inside the attachment resolve against the host page's URL.
+- Inline styles set directly on elements work as expected.
+:::
+
+:::caution[Attachments are 2D-only]
+An attachment is a pure 2D rendering surface. Spatialized content cannot be nested inside it. The following components degrade automatically when placed inside `<AttachmentAsset>`:
+
+| Component | Behavior inside an attachment |
+| --- | --- |
+| `<Reality>` | Not rendered (returns null), with a console warning. |
+| `<SpatialDiv>` | Rendered as plain HTML; spatial props are ignored, while layout and styles still work. |
+| [`<Model>`](./Model.md) | Rendered as the standard `<model>` element, without spatialization. |
+
+Attachments also do not yet support orientation policies such as billboarding (always facing the user).
+:::

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/react-sdk/react-components/Reality.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api/react-sdk/react-components/Reality.md
@@ -238,7 +238,14 @@ useEffect(() => {
 
 ## 附着实体 {#attachment-entity}
 
-`<AttachmentEntity>` 是一个类似 `<Plane>` 的 Entity，可以引用[预先声明好的 2D HTML/CSS 内容](#3d-assets)，让它附着在自己表面上。
+Attachment（附着）能力可以把可交互的 2D HTML/React 内容——按钮、文字标签、HUD、信息面板等——作为浮动面板附着到 `<Reality>` 场景中的 3D Entity 上。附着的内容和宿主页面共享同一棵 React 组件树和状态：在 attachment 里点击按钮可以更新宿主页面的状态，宿主页面的状态变化也会实时反映到 attachment 里。
+
+这套 API 由两个职责分离的组件组成：
+
+- `<AttachmentAsset>` 声明**渲染什么**（2D 内容模板），属于 [3D 资产声明](#3d-assets)，作为 `<Reality>` 的顶层子节点放在 `<World>` 之外。
+- `<AttachmentEntity>` 声明**渲染在哪里**（位置、大小、父 Entity），在 `<World>` 内使用。
+
+这种「资产 vs 实体」的分离和 [`<ModelAsset>` / `<ModelEntity>`](#model-entity) 的模式一致，同样支持一对多渲染：同一个内容模板可以同时渲染到多个 3D 位置上。
 
 :::caution[当前限制]
 WebSpatial SDK 后续版本会让 `<AttachmentEntity>` 像 `<Plane>` 一样支持 `width` 和 `height`（当前版本暂不支持）和完整 [Transform 属性](#3d-entity)（当前版本只支持 `position`），需要临时用 `size` 属性设置大小（单位是跟 2D 内容一样的 `px`）。
@@ -263,3 +270,107 @@ WebSpatial SDK 后续版本会让 `<AttachmentEntity>` 像 `<Plane>` 一样支�
   </World>
 </Reality>
 ```
+
+### `<AttachmentAsset>` 属性 {#attachmentasset-props}
+
+`name`
+
+必填。字符串标识符，把这个内容模板关联到一个或多个 `<AttachmentEntity>`，必须和对应实体上的 `attachment` 属性一致。
+
+`children`
+
+要渲染在 attachment 中的 React 内容，可以是任意合法的 React JSX——div、按钮、带样式的组件、有状态的组件等。这些内容共享宿主页面的 React 组件树，props、context 和状态都可以自然流动。
+
+使用规则：
+
+- `<AttachmentAsset>` 必须作为 `<Reality>` 的直接子节点，放在 `<World>` 之外。
+- 如果没有任何 `<AttachmentEntity>` 引用这个 `name`，内容不会被渲染。
+- 多个 `<AttachmentEntity>` 引用同一个 `name` 时，每个位置都会渲染一份相同的内容模板。
+
+### `<AttachmentEntity>` 属性 {#attachmententity-props}
+
+`attachment`
+
+必填。字符串，需要和对应 `<AttachmentAsset>` 的 `name` 属性一致。
+
+`position`
+
+可选。attachment 相对父 Entity 的本地位置，和其他 [Transform 属性](#3d-entity)一样使用 `m` 单位。默认在原点。
+
+`size`
+
+必填。对象 `{ width: number, height: number }`，设置 attachment 的尺寸，单位是和 2D 内容一样的 `px`。
+
+`<AttachmentEntity>` 必须放在 `<World>` 内、作为某个 Entity 的后代节点使用。它继承父 Entity 的变换：父 Entity 移动时，attachment 会跟随移动。
+
+`attachment`、`position` 和 `size` 都可以在运行时动态修改，attachment 会相应切换到新的内容模板或更新位置和大小。组件卸载时，对应的原生 attachment 会被自动销毁。
+
+### 共享状态与一对多渲染 {#shared-state-and-one-to-many-rendering}
+
+同一个内容模板可以同时渲染到多个 3D 位置上，且附着的内容始终和宿主页面的状态保持连接：
+
+```js
+import { useState } from "react";
+import {
+  Reality,
+  AttachmentAsset,
+  World,
+  Entity,
+  Sphere,
+  AttachmentEntity,
+} from "@webspatial/react-sdk";
+
+function LabeledSpheres() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Reality style={{ width: "500px", height: "500px", "--xr-depth": 100 }}>
+      {/* One content template, shared with the host page's state */}
+      <AttachmentAsset name="counter">
+        <button onClick={() => setCount(count + 1)}>Clicked {count}</button>
+      </AttachmentAsset>
+      <World>
+        {/* The same template is rendered at two 3D positions */}
+        <Entity position={{ x: -0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+        <Entity position={{ x: 0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+      </World>
+    </Reality>
+  );
+}
+```
+
+:::info[样式自动继承]
+attachment 里的 2D 内容会自动继承宿主页面的样式：
+
+- 宿主页面的全局样式（如 `<link rel="stylesheet">` 和 `<style>`）会自动同步到 attachment 中。
+- 根元素上的 class 名也会同步，因此 Tailwind 这类基于工具类的方案可以直接使用。
+- 开发阶段由热更新（HMR）注入的新样式会被自动同步。
+- attachment 内的相对 URL 会按宿主页面的地址正确解析。
+- 直接写在元素上的内联样式正常生效。
+:::
+
+:::caution[attachment 只支持 2D 内容]
+attachment 是纯 2D 渲染表面，不能在其中嵌套空间化内容。把以下组件放进 `<AttachmentAsset>` 时会自动降级：
+
+| 组件 | 在 attachment 内的行为 |
+| --- | --- |
+| `<Reality>` | 不渲染（返回 null），并在控制台输出警告。 |
+| `<SpatialDiv>` | 降级为普通 HTML 渲染；空间属性被忽略，布局和样式仍然生效。 |
+| [`<Model>`](./Model.md) | 降级为标准 `<model>` 元素渲染，无空间化能力。 |
+
+attachment 暂不支持 billboard（始终朝向用户）之类的朝向策略。
+:::

--- a/packages/starter/docs/api/react-sdk/react-components/Reality.md
+++ b/packages/starter/docs/api/react-sdk/react-components/Reality.md
@@ -239,7 +239,14 @@ useEffect(() => {
 
 ## Attachment Entity
 
-`<AttachmentEntity>` is an Entity similar to `<Plane>`. It can reference [predeclared 2D HTML/CSS content](#3d-assets) and attach that content onto its own surface.
+The Attachment API lets you render interactive 2D HTML/React content — buttons, labels, HUDs, info panels — as floating panels attached to 3D entities inside `<Reality>`. The attached content shares the same React component tree and state as the host page: clicking a button inside an attachment can update the host page's state, and host page state changes are reflected inside the attachment in real time.
+
+This API consists of two components with separated responsibilities:
+
+- `<AttachmentAsset>` declares **what** to render (the 2D content template). It is a [3D asset declaration](#3d-assets) placed among the top-level children of `<Reality>`, outside `<World>`.
+- `<AttachmentEntity>` declares **where** to render it (position, size, and parent Entity). It is used inside `<World>`.
+
+This asset-vs-entity separation follows the same pattern as [`<ModelAsset>` / `<ModelEntity>`](#model-entity), and supports one-to-many rendering in the same way: a single content template can be rendered at multiple 3D positions at the same time.
 
 > [!CAUTION]
 > **Current limitation**
@@ -265,3 +272,109 @@ useEffect(() => {
   </World>
 </Reality>
 ```
+
+### `<AttachmentAsset>` Props
+
+`name`
+
+Required. A string identifier that links this content template to one or more `<AttachmentEntity>` instances. It must match the `attachment` prop on the corresponding entities.
+
+`children`
+
+The React content to render inside the attachment. This can be any valid React JSX — divs, buttons, styled components, stateful components, and so on. The content shares the host page's React tree, so props, context, and state flow naturally.
+
+Usage rules:
+
+- `<AttachmentAsset>` must be a direct child of `<Reality>`, outside `<World>`.
+- If no `<AttachmentEntity>` references the given `name`, the content is not rendered.
+- When multiple `<AttachmentEntity>` instances reference the same `name`, a copy of the same content template is rendered at each position.
+
+### `<AttachmentEntity>` Props
+
+`attachment`
+
+Required. A string matching the `name` prop on the corresponding `<AttachmentAsset>`.
+
+`position`
+
+Optional. The attachment's local position relative to its parent Entity, using the same `m` unit as other [Transform props](#3d-entity). Defaults to the origin.
+
+`size`
+
+Required. An object `{ width: number, height: number }` that sets the attachment's frame dimensions, with the same `px` unit used by 2D content.
+
+`<AttachmentEntity>` must be used inside `<World>` as a descendant of an Entity. It inherits the parent Entity's transform: when the parent Entity moves, the attachment follows it.
+
+`attachment`, `position`, and `size` can all be changed at runtime. The attachment switches to the new content template or updates its position and size accordingly. When the component unmounts, the corresponding native attachment is destroyed automatically.
+
+### Shared State and One-to-Many Rendering
+
+One content template can be rendered at multiple 3D positions at the same time, and the attached content stays connected to the host page's state:
+
+```js
+import { useState } from "react";
+import {
+  Reality,
+  AttachmentAsset,
+  World,
+  Entity,
+  Sphere,
+  AttachmentEntity,
+} from "@webspatial/react-sdk";
+
+function LabeledSpheres() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Reality style={{ width: "500px", height: "500px", "--xr-depth": 100 }}>
+      {/* One content template, shared with the host page's state */}
+      <AttachmentAsset name="counter">
+        <button onClick={() => setCount(count + 1)}>Clicked {count}</button>
+      </AttachmentAsset>
+      <World>
+        {/* The same template is rendered at two 3D positions */}
+        <Entity position={{ x: -0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+        <Entity position={{ x: 0.5, y: 0, z: 0.3 }}>
+          <Sphere radius={0.1} />
+          <AttachmentEntity
+            attachment="counter"
+            position={{ x: 0, y: 0.25, z: 0 }}
+            size={{ width: 140, height: 48 }}
+          />
+        </Entity>
+      </World>
+    </Reality>
+  );
+}
+```
+
+> [!NOTE]
+> **Styles are inherited automatically**
+>
+> The 2D content inside an attachment automatically inherits styles from the host page:
+>
+> - Global styles on the host page, such as `<link rel="stylesheet">` and `<style>`, are synced into the attachment automatically.
+> - Class names on the root element are synced as well, so utility-class approaches such as Tailwind work directly.
+> - During development, new styles injected by hot module replacement (HMR) are picked up automatically.
+> - Relative URLs inside the attachment resolve against the host page's URL.
+> - Inline styles set directly on elements work as expected.
+
+> [!CAUTION]
+> **Attachments are 2D-only**
+>
+> An attachment is a pure 2D rendering surface. Spatialized content cannot be nested inside it. The following components degrade automatically when placed inside `<AttachmentAsset>`:
+>
+> | Component | Behavior inside an attachment |
+> | --- | --- |
+> | `<Reality>` | Not rendered (returns null), with a console warning. |
+> | `<SpatialDiv>` | Rendered as plain HTML; spatial props are ignored, while layout and styles still work. |
+> | [`<Model>`](./Model.md) | Rendered as the standard `<model>` element, without spatialization. |
+>
+> Attachments also do not yet support orientation policies such as billboarding (always facing the user).


### PR DESCRIPTION
Expands the Attachment coverage in `/docs/api/react-sdk/react-components/Reality`, based on the SDK feature doc: https://github.com/webspatial/webspatial-sdk/blob/main/docs/Attachments.md

## Changes

- Rewrite the Attachment Entity intro around the core concepts: attached 2D content shares the host page's React tree and state; `<AttachmentAsset>` declares what to render (outside `<World>`) while `<AttachmentEntity>` declares where (inside `<World>`); one template can render at multiple 3D positions (same asset-vs-entity pattern as `ModelAsset`/`ModelEntity`)
- Add prop references for `<AttachmentAsset>` (`name`, `children`) and `<AttachmentEntity>` (`attachment`, `position`, `size`), plus placement rules and runtime behavior (follows parent Entity, runtime-updatable props, destroyed on unmount)
- Add a shared-state one-to-many example
- Document automatic style inheritance (global styles, class names, HMR, relative URLs) as an info admonition
- Document the 2D-only nesting guards (`<Reality>`/`<SpatialDiv>`/`<Model>` degradation) as a caution admonition

Applied consistently to the English latest docs, the Simplified Chinese mirror (`i18n/zh-Hans/.../current/`), and the starter AI-facing mirror (`packages/starter/docs/`, admonitions adapted to GitHub alerts). Heading anchors verified identical across locales.

## Validation

- `pnpm build` and `pnpm build:test` pass
- `pnpm starter:test` passes (12/12)

## Not included (pending confirmation)

- A minimum-SDK-version note for this section — waiting on the actual npm version number (the SDK doc's compatibility table says "WebSpatial April")
- Screenshot for the new example — needs an asset from engineering
- `position` is documented with the object form `{ x, y, z }` used by existing docs and all other Transform props; the SDK doc mentions a `[x, y, z]` tuple — please confirm which one the implementation accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
